### PR TITLE
Circular rendering support and tests

### DIFF
--- a/epixcloud.js
+++ b/epixcloud.js
@@ -159,6 +159,21 @@ define(['jquery', 'underscore'], function($, _){
         });
     }
 
+    function isBoxInCircle(box, containerSize){
+        var radius = Math.floor(_.min(containerSize) / 2),
+            centerX = Math.floor(containerSize[0] / 2),
+            centerY = Math.floor(containerSize[1] / 2);
+
+        return isPointInCircle(centerX, centerY, box[0], box[1], radius) &&
+               isPointInCircle(centerX, centerY, box[0], box[3], radius) &&
+               isPointInCircle(centerX, centerY, box[2], box[1], radius) &&
+               isPointInCircle(centerX, centerY, box[2], box[3], radius);
+    }
+
+    function isBoxInRectangle(box, containerSize){
+        return box[0] > 0 && box[1] > 0 && box[2] < containerSize[0] && box[3] < containerSize[1];
+    }
+
     EpixCloud.prototype.init = function(){
         var self = this;
 
@@ -212,34 +227,19 @@ define(['jquery', 'underscore'], function($, _){
         };
     };
 
+    EpixCloud.prototype.isBoxInContainer = function(box){
+        if(this.circular){
+            return isBoxInCircle(box, this.containerSize);
+        }
+        return isBoxInRectangle(box, this.containerSize);
+    };
+
     EpixCloud.prototype.calculateFigureSpace = function(){
         var self = this;
 
         this.figureSpace = _(this.topics).map(function(topic){
             return self.measureTopicBox(topic);
         });
-    };
-
-    EpixCloud.prototype.isBoxInContainer = function(box){
-        if(this.circular){
-            return this.isBoxInCircle(box);
-        }
-        return this.isBoxInRectangle(box);
-    };
-
-    EpixCloud.prototype.isBoxInCircle = function(box){
-        var radius = Math.floor(_.min(this.containerSize) / 2),
-            centerX = Math.floor(this.containerSize[0] / 2),
-            centerY = Math.floor(this.containerSize[1] / 2);
-
-        return isPointInCircle(centerX, centerY, box[0], box[1], radius) &&
-               isPointInCircle(centerX, centerY, box[0], box[3], radius) &&
-               isPointInCircle(centerX, centerY, box[2], box[1], radius) &&
-               isPointInCircle(centerX, centerY, box[2], box[3], radius);
-    };
-
-    EpixCloud.prototype.isBoxInRectangle = function(box){
-        return box[0] > 0 && box[1] > 0 && box[2] < this.containerSize[0] && box[3] < this.containerSize[1];
     };
 
     EpixCloud.prototype.isSpaceAvailable = function(box){

--- a/tests/epixcloud.tests.js
+++ b/tests/epixcloud.tests.js
@@ -314,16 +314,6 @@ define([
                     inContainerStub.restore();
                 });
 
-                it('isBoxInContainer delegates to isBoxInRectangle by default', function(){
-                    var inBoxStub = sinon.stub(EpixCloud.prototype, 'isBoxInRectangle');
-
-                    cloud = new EpixCloud({topics: [], $el: $('<div style="width:200px;height:200px;"/>')});
-                    cloud.isBoxInContainer([10,10,150,37]);
-
-                    expect(inBoxStub.calledOnce).toEqual(true);
-                    inBoxStub.restore();
-                });
-
                 it('correctly finds a place for the first topic passed, starting in the center of the $el',function(){
                     cloud = new EpixCloud({
                         topics: [],
@@ -856,26 +846,6 @@ define([
             });
 
             describe('circular rendering', function(){
-                it('isBoxInContainer calls isBoxInCircle if the circle option is set on initialisation', function(){
-                    var circleStub = sinon.stub(EpixCloud.prototype, 'isBoxInCircle');
-
-                    cloud = new EpixCloud({circle: true, topics: [], $el: $('<div style="width:200px;height:200px;"/>')});
-                    cloud.isBoxInContainer([10,10,150,37]);
-
-                    expect(circleStub.calledOnce).toEqual(true);
-                    circleStub.restore();
-                });
-
-                it('does not call isBoxInRectangle if the circle option is set on initialisation', function(){
-                    var rectStub = sinon.stub(EpixCloud.prototype, 'isBoxInRectangle');
-
-                    cloud = new EpixCloud({circle: true, topics: [], $el: $('<div style="width:200px;height:200px;"/>')});
-                    cloud.isBoxInContainer([10,10,150,37]);
-
-                    expect(rectStub.called).toEqual(false);
-                    rectStub.restore();
-                });
-
                 it('resizes the viewport to a square on render if the circle option is set', function(){
                     $testArea.css({
                         width: 300,


### PR DESCRIPTION
Adds support for rendering to circles rather than rectangles.

Off by default, to use circles:

``` js
new EpixCloud({
  circle: true
});
```
