### PR TITLE
CC-4747 Fix topics not positioning properly when external scale applied

### DIFF
--- a/epixcloud.js
+++ b/epixcloud.js
@@ -319,11 +319,10 @@ define(['jquery', 'underscore'], function($, _){
 
         this.$el.find('.' + this.wordClass).each(function(){
             var $this = $(this),
-                pos = $this.position(),
                 w = $this.outerWidth(),
                 h = $this.outerHeight(),
-                t = pos.top,
-                l = pos.left,
+                t = this.offsetTop,
+                l = this.offsetLeft,
                 r = l + w,
                 b = t + h;
 

--- a/tests/epixcloud.tests.js
+++ b/tests/epixcloud.tests.js
@@ -861,5 +861,37 @@ define([
             });
         });
 
+        describe('when rendered in an externally scaled element and the noscale option has not been passed', function(){
+            var $topics;
+
+            beforeEach(function(){
+                var $testArea = $('<div style="width:600px;height:600px;"/>').appendTo('body');
+
+                cloud = new EpixCloud({topics: testTopics, $el: $testArea});
+
+                $testArea.css({
+                    '-webkit-transform': 'scale(3)',
+                    '-moz-transform': 'scale(3)',
+                    'transform': 'scale(3)'
+                });
+
+                cloud.render();
+
+                $topics = $testArea.find('.epixword');
+            });
+
+            it('does not plot any topic outside of the container', function(){
+                expect($topics.get(0).offsetLeft).toBeGreaterThan(0);
+                expect($topics.get(0).offsetTop).toBeGreaterThan(0);
+                expect($topics.get(1).offsetLeft).toBeGreaterThan(0);
+                expect($topics.get(1).offsetTop).toBeGreaterThan(0);
+                expect($topics.get(2).offsetLeft).toBeGreaterThan(0);
+                expect($topics.get(2).offsetTop).toBeGreaterThan(0);
+                expect($topics.get(3).offsetLeft).toBeGreaterThan(0);
+                expect($topics.get(3).offsetTop).toBeGreaterThan(0);
+                expect($topics.get(4).offsetLeft).toBeGreaterThan(0);
+                expect($topics.get(4).offsetTop).toBeGreaterThan(0);
+            });
+        });
     });
 });


### PR DESCRIPTION
Now uses `offsetTop` and `offsetLeft` instead of `$.position` to position words. The problem with `$.position` is that it scales the values it returns. The coords system used to position elements conversely does **not** scale.

This meant then when working out how the topic cloud could fit inside its container, it would think it was far larger than it actually was, leading it to be rendered very small _(in the case of the scale factor being > 1)_ in order to fit the cloud inside. 

As it was also lead to believe that the topmost and leftmost edges were actually (whatever scale factor was passed) less or greater than what it actually was. This lead to topics also being rendered outside of the bounding element.

Simply using position values that don't scale fixes both of these problems.